### PR TITLE
(WIP) Add cluster asset to launch an openshift cluster

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -13,6 +13,7 @@ import (
 var (
 	installConfigCommand   = kingpin.Command("install-config", "Generate the Install Config asset")
 	ignitionConfigsCommand = kingpin.Command("ignition-configs", "Generate the Ignition Config assets")
+	clusterCommand         = kingpin.Command("cluster", "Create an OpenShift cluster")
 
 	dirFlag  = kingpin.Flag("dir", "assets directory").Default(".").String()
 	logLevel = kingpin.Flag("log-level", "log level (e.g. \"debug\")").Default("warn").Enum("debug", "info", "warn", "error", "fatal", "panic")
@@ -32,6 +33,11 @@ func main() {
 			assetStock.BootstrapIgnition(),
 			assetStock.MasterIgnition(),
 			assetStock.WorkerIgnition(),
+		}
+	case clusterCommand.FullCommand():
+		targetAssets = []asset.Asset{
+			// TODO(yifan): Add kubeconfig-admin.
+			assetStock.Cluster(),
 		}
 	}
 

--- a/installer/pkg/workflow/BUILD.bazel
+++ b/installer/pkg/workflow/BUILD.bazel
@@ -5,10 +5,8 @@ go_library(
     srcs = [
         "convert.go",
         "destroy.go",
-        "executor.go",
         "init.go",
         "install.go",
-        "terraform.go",
         "utils.go",
         "workflow.go",
     ],
@@ -17,6 +15,7 @@ go_library(
     deps = [
         "//installer/pkg/config-generator:go_default_library",
         "//installer/pkg/copy:go_default_library",
+        "//pkg/terraform:go_default_library",
         "//pkg/types/config:go_default_library",
         "//vendor/github.com/Sirupsen/logrus:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",

--- a/installer/pkg/workflow/destroy.go
+++ b/installer/pkg/workflow/destroy.go
@@ -41,15 +41,15 @@ func DestroyWorkflow(clusterDir string, contOnErr bool) Workflow {
 }
 
 func destroyAssetsStep(m *metadata) error {
-	return runDestroyStep(m, assetsStep)
+	return runDestroyStep(m, terraform.AssetsStep)
 }
 
 func destroyInfraStep(m *metadata) error {
-	return runDestroyStep(m, infraStep)
+	return runDestroyStep(m, terraform.InfraStep)
 }
 
 func destroyBootstrapStep(m *metadata) error {
-	return runDestroyStep(m, bootstrapStep)
+	return runDestroyStep(m, terraform.BootstrapStep)
 }
 
 func destroyWorkersStep(m *metadata) error {
@@ -137,7 +137,13 @@ func runDestroyStep(m *metadata, step string, extraArgs ...string) error {
 		// there is no statefile, therefore nothing to destroy for this step
 		return nil
 	}
-	templateDir, err := findStepTemplates(step, m.cluster.Platform)
+
+	dir, err := baseLocation()
+	if err != nil {
+		return err
+	}
+
+	templateDir, err := terraform.FindStepTemplates(dir, step, m.cluster.Platform)
 	if err != nil {
 		return err
 	}

--- a/installer/pkg/workflow/destroy.go
+++ b/installer/pkg/workflow/destroy.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/openshift/installer/pkg/terraform"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -132,7 +133,7 @@ func deleteWorkerMachineSet(client *clientset.Clientset) error {
 }
 
 func runDestroyStep(m *metadata, step string, extraArgs ...string) error {
-	if !hasStateFile(m.clusterDir, step) {
+	if !terraform.HasStateFile(m.clusterDir, step) {
 		// there is no statefile, therefore nothing to destroy for this step
 		return nil
 	}
@@ -141,7 +142,7 @@ func runDestroyStep(m *metadata, step string, extraArgs ...string) error {
 		return err
 	}
 
-	return tfDestroy(m.clusterDir, step, templateDir, extraArgs...)
+	return terraform.Destroy(m.clusterDir, step, templateDir, extraArgs...)
 }
 
 func buildClusterClient(kubeconfig string) (*clientset.Clientset, error) {

--- a/installer/pkg/workflow/install.go
+++ b/installer/pkg/workflow/install.go
@@ -28,29 +28,34 @@ func InstallWorkflow(clusterDir string) Workflow {
 }
 
 func installAssetsStep(m *metadata) error {
-	return runInstallStep(m, assetsStep)
+	return runInstallStep(m, terraform.AssetsStep)
 }
 
 func installInfraStep(m *metadata) error {
-	return runInstallStep(m, infraStep)
+	return runInstallStep(m, terraform.InfraStep)
 }
 
 func installBootstrapStep(m *metadata) error {
-	if !terraform.HasStateFile(m.clusterDir, bootstrapStep) {
-		return runInstallStep(m, bootstrapStep)
+	if !terraform.HasStateFile(m.clusterDir, terraform.BootstrapStep) {
+		return runInstallStep(m, terraform.BootstrapStep)
 	}
 	return nil
 }
 
 func runInstallStep(m *metadata, step string, extraArgs ...string) error {
-	templateDir, err := findStepTemplates(step, m.cluster.Platform)
+	dir, err := baseLocation()
+	if err != nil {
+		return err
+	}
+	templateDir, err := terraform.FindStepTemplates(dir, step, m.cluster.Platform)
 	if err != nil {
 		return err
 	}
 	if err := terraform.Init(m.clusterDir, templateDir); err != nil {
 		return err
 	}
-	return terraform.Apply(m.clusterDir, step, templateDir, extraArgs...)
+	_, err = terraform.Apply(m.clusterDir, step, templateDir, extraArgs...)
+	return err
 }
 
 func generateIgnConfigStep(m *metadata) error {

--- a/installer/pkg/workflow/install.go
+++ b/installer/pkg/workflow/install.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/installer/installer/pkg/config-generator"
+	"github.com/openshift/installer/pkg/terraform"
 )
 
 // InstallWorkflow creates new instances of the 'install' workflow,
@@ -35,7 +36,7 @@ func installInfraStep(m *metadata) error {
 }
 
 func installBootstrapStep(m *metadata) error {
-	if !hasStateFile(m.clusterDir, bootstrapStep) {
+	if !terraform.HasStateFile(m.clusterDir, bootstrapStep) {
 		return runInstallStep(m, bootstrapStep)
 	}
 	return nil
@@ -46,10 +47,10 @@ func runInstallStep(m *metadata, step string, extraArgs ...string) error {
 	if err != nil {
 		return err
 	}
-	if err := tfInit(m.clusterDir, templateDir); err != nil {
+	if err := terraform.Init(m.clusterDir, templateDir); err != nil {
 		return err
 	}
-	return tfApply(m.clusterDir, step, templateDir, extraArgs...)
+	return terraform.Apply(m.clusterDir, step, templateDir, extraArgs...)
 }
 
 func generateIgnConfigStep(m *metadata) error {

--- a/installer/pkg/workflow/utils.go
+++ b/installer/pkg/workflow/utils.go
@@ -13,42 +13,10 @@ import (
 )
 
 const (
-	assetsStep       = "assets"
-	bootstrapStep    = "bootstrap"
 	binaryPrefix     = "installer"
 	configFileName   = "config.yaml"
-	infraStep        = "infra"
 	internalFileName = "internal.yaml"
-	stepsBaseDir     = "steps"
 )
-
-// returns the directory containing templates for a given step. If platform is
-// specified, it looks for a subdirectory with platform first, falling back if
-// there are no platform-specific templates for that step
-func findStepTemplates(stepName string, platform config.Platform) (string, error) {
-	base, err := baseLocation()
-	if err != nil {
-		return "", fmt.Errorf("error looking up step %s templates: %v", stepName, err)
-	}
-	stepDir := filepath.Join(base, stepsBaseDir, stepName)
-	for _, path := range []string{
-		filepath.Join(stepDir, string(platform)),
-		stepDir} {
-
-		stat, err := os.Stat(path)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return "", fmt.Errorf("invalid path for %q templates: %s", base, err)
-		}
-		if !stat.IsDir() {
-			return "", fmt.Errorf("invalid path for %q templates", base)
-		}
-		return path, nil
-	}
-	return "", os.ErrNotExist
-}
 
 func generateClusterConfigMaps(m *metadata) error {
 	clusterGeneratedPath := filepath.Join(m.clusterDir, generatedPath)

--- a/pkg/asset/cluster/BUILD.bazel
+++ b/pkg/asset/cluster/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cluster.go",
+        "doc.go",
+        "stock.go",
+        "tfvar.go",
+    ],
+    importpath = "github.com/openshift/installer/pkg/asset/cluster",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/asset:go_default_library",
+        "//pkg/asset/ignition:go_default_library",
+        "//pkg/asset/installconfig:go_default_library",
+        "//pkg/terraform:go_default_library",
+        "//pkg/types/config:go_default_library",
+    ],
+)

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -1,0 +1,101 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/terraform"
+	"github.com/openshift/installer/pkg/types/config"
+)
+
+// Cluster uses the terraform executable to launch a cluster
+// with the given terraform tfvar and generated templates.
+type Cluster struct {
+	// The root directory of the generated assets.
+	rootDir string
+	tfvars  asset.Asset
+
+	// TODO(yifan): Add kubeconfig-admin as a dependency
+	// so we can use it to determine when the cluster is
+	// fully up.
+}
+
+var _ asset.Asset = (*Cluster)(nil)
+
+// Name returns the human-friendly name of the asset.
+func (c *Cluster) Name() string {
+	return "Cluster"
+}
+
+// Dependencies returns the direct dependency for launching
+// the cluster.
+func (c *Cluster) Dependencies() []asset.Asset {
+	return []asset.Asset{c.tfvars}
+}
+
+// Generate launches the cluster and generates the terraform state file on disk.
+func (c *Cluster) Generate(parents map[asset.Asset]*asset.State) (*asset.State, error) {
+	state, ok := parents[c.tfvars]
+	if !ok {
+		return nil, fmt.Errorf("failed to get terraform.tfvar state in the parent asset states")
+	}
+
+	var tfvars config.Cluster
+	if err := json.Unmarshal(state.Contents[0].Data, &tfvars); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal terraform tfvars file: %v", err)
+	}
+
+	steps = []string{
+		terraform.InfraStep,
+		terraform.BootstrapStep,
+	}
+
+	dir, err := baseLocation()
+	if err != nil {
+		return nil, err
+	}
+
+	var result asset.State
+
+	for _, step := range steps {
+		templateDir, err := terraform.FindStepTemplates(dir, step, tfvars.Platform)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := terraform.Init(c.rootDir, templateDir); err != nil {
+			return nil, err
+		}
+
+		stateFile, err := terraform.Apply(c.rootDir, step, templateDir)
+		if err != nil {
+			return nil, err
+		}
+
+		data, err := ioutil.ReadFile(state)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tfstate file %q: %v", stateFile, err)
+		}
+
+		result.Contents = append(result.Contents, asset.Content{
+			Name: stateFile,
+			Data: data,
+		})
+	}
+
+	return &result, nil
+}
+
+// baseLocation returns the parent dir of the terraform templates (steps, modules).
+// The manifests should live in the same dir as the installer executable.
+func baseLocation() (string, error) {
+	ex, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("undetermined location of own executable: %s", err)
+	}
+	return filepath.Dir(ex), nil
+}

--- a/pkg/asset/cluster/stock.go
+++ b/pkg/asset/cluster/stock.go
@@ -10,11 +10,14 @@ import (
 type Stock interface {
 	// TFVars is the asset that generates the terraform.tfvar file
 	TFVars() asset.Asset
+	// Cluster is the asset that creates the cluster.
+	Cluster() asset.Asset
 }
 
 // StockImpl is the implementation of the cluster asset stock.
 type StockImpl struct {
-	tfvars asset.Asset
+	tfvars  asset.Asset
+	cluster asset.Asset
 }
 
 var _ Stock = (*StockImpl)(nil)
@@ -28,7 +31,15 @@ func (s *StockImpl) EstablishStock(rootDir string, installConfigStock installcon
 		masterIgnition:    ignitionStock.MasterIgnition(),
 		workerIgnition:    ignitionStock.WorkerIgnition(),
 	}
+
+	s.cluster = &Cluster{
+		rootDir: rootDir,
+		tfvars:  s.tfvars,
+	}
 }
 
 // TFVars returns the terraform tfvar asset.
 func (s *StockImpl) TFVars() asset.Asset { return s.tfvars }
+
+// Cluster returns the cluster asset.
+func (s *StockImpl) Cluster() asset.Asset { return s.cluster }

--- a/pkg/terraform/BUILD.bazel
+++ b/pkg/terraform/BUILD.bazel
@@ -3,9 +3,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "executor.go",
         "terraform.go",
     ],
     importpath = "github.com/openshift/installer/pkg/terraform",
     visibility = ["//visibility:public"],
+    deps = ["//pkg/types/config:go_default_library"],
 )

--- a/pkg/terraform/BUILD.bazel
+++ b/pkg/terraform/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "executor.go",
+        "terraform.go",
+    ],
+    importpath = "github.com/openshift/installer/pkg/terraform",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/terraform/doc.go
+++ b/pkg/terraform/doc.go
@@ -1,0 +1,4 @@
+// Package terraform contains the utilities that's used for invoking
+// terraform executable under the given directory with the given
+// templates.
+package terraform

--- a/pkg/terraform/executor.go
+++ b/pkg/terraform/executor.go
@@ -1,4 +1,4 @@
-package workflow
+package terraform
 
 import (
 	"errors"

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -3,7 +3,24 @@ package terraform
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+
+	"github.com/openshift/installer/pkg/types/config"
+)
+
+const (
+	// AssetsStep is the name of the step that generates the assets.
+	// This is deprecated.
+	// TODO(yifan) Remove this when removing the asset step.
+	AssetsStep = "assets"
+
+	// BootstrapStep is the name of the step that runs the bootstrap.
+	BootstrapStep = "bootstrap"
+	// InfraStep is the name of the step that sets up infra.
+	InfraStep = "infra"
+
+	stepsBaseDir = "steps"
 )
 
 func terraformExec(clusterDir string, args ...string) error {
@@ -21,16 +38,18 @@ func terraformExec(clusterDir string, args ...string) error {
 }
 
 // Apply runs "terraform apply" with the given clusterDir, templateDir and extra args.
-// It outputs the tfstate file.
-func Apply(clusterDir string, state string, templateDir string, extraArgs ...string) error {
+// It returns the absolute path of the tfstate file.
+func Apply(clusterDir string, state string, templateDir string, extraArgs ...string) (string, error) {
+	stateFileName := fmt.Sprintf("%s.tfstate", state)
 	defaultArgs := []string{
 		"apply",
 		"-auto-approve",
-		fmt.Sprintf("-state=%s.tfstate", state),
+		fmt.Sprintf("-state=%s", stateFileName),
 	}
 	extraArgs = append(extraArgs, templateDir)
 	args := append(defaultArgs, extraArgs...)
-	return terraformExec(clusterDir, args...)
+
+	return path.Join(clusterDir, stateFileName), terraformExec(clusterDir, args...)
 }
 
 // Destroy runs "terraform destory" with the given clusterDir, templateDir, state file
@@ -56,4 +75,28 @@ func HasStateFile(stateDir string, stateFile string) bool {
 	stepStateFile := filepath.Join(stateDir, fmt.Sprintf("%s.tfstate", stateFile))
 	_, err := os.Stat(stepStateFile)
 	return !os.IsNotExist(err)
+}
+
+// FindStepTemplates returns the directory containing templates for a given step.
+// If platform is specified, it looks for a subdirectory with platform first,
+// falling back if there are no platform-specific templates for that step.
+func FindStepTemplates(dir, stepName string, platform config.Platform) (string, error) {
+	stepDir := filepath.Join(dir, stepsBaseDir, stepName)
+	for _, path := range []string{
+		filepath.Join(stepDir, string(platform)),
+		stepDir} {
+
+		stat, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", fmt.Errorf("invalid path for %q templates: %s", path, err)
+		}
+		if !stat.IsDir() {
+			return "", fmt.Errorf("invalid path for %q templates", path)
+		}
+		return path, nil
+	}
+	return "", os.ErrNotExist
 }

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -1,4 +1,4 @@
-package workflow
+package terraform
 
 import (
 	"fmt"
@@ -20,7 +20,9 @@ func terraformExec(clusterDir string, args ...string) error {
 	return nil
 }
 
-func tfApply(clusterDir string, state string, templateDir string, extraArgs ...string) error {
+// Apply runs "terraform apply" with the given clusterDir, templateDir and extra args.
+// It outputs the tfstate file.
+func Apply(clusterDir string, state string, templateDir string, extraArgs ...string) error {
 	defaultArgs := []string{
 		"apply",
 		"-auto-approve",
@@ -31,7 +33,9 @@ func tfApply(clusterDir string, state string, templateDir string, extraArgs ...s
 	return terraformExec(clusterDir, args...)
 }
 
-func tfDestroy(clusterDir, state, templateDir string, extraArgs ...string) error {
+// Destroy runs "terraform destory" with the given clusterDir, templateDir, state file
+// and extra args.
+func Destroy(clusterDir, state, templateDir string, extraArgs ...string) error {
 	defaultArgs := []string{
 		"destroy",
 		"-force",
@@ -42,12 +46,14 @@ func tfDestroy(clusterDir, state, templateDir string, extraArgs ...string) error
 	return terraformExec(clusterDir, args...)
 }
 
-func tfInit(clusterDir, templateDir string) error {
+// Init runs "terraform init" with the given clusterDir and templateDir.
+func Init(clusterDir, templateDir string) error {
 	return terraformExec(clusterDir, "init", templateDir)
 }
 
-func hasStateFile(stateDir string, stateName string) bool {
-	stepStateFile := filepath.Join(stateDir, fmt.Sprintf("%s.tfstate", stateName))
+// HasStateFile returns true if the stateFile exists under stateDir.
+func HasStateFile(stateDir string, stateFile string) bool {
+	stepStateFile := filepath.Join(stateDir, fmt.Sprintf("%s.tfstate", stateFile))
 	_, err := os.Stat(stepStateFile)
 	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
- Move some helper function from `installer/pkg/workflow` to `pkg/terraform`
- Create a `cluster` asset that uses the `tfvars` asset, terraform templates and terraform binary to launch a cluster
- Add a `clutser` target in the CLI so users can run the CLI to create a cluster.